### PR TITLE
Dynamic recipe quantities

### DIFF
--- a/src/assets/recipes/chocolate-cake-cookies.json
+++ b/src/assets/recipes/chocolate-cake-cookies.json
@@ -4,10 +4,10 @@
   "subtitle2": "This dessert is a fan favorite by college students! Made from chocolate cake mix the cookies come together super fast. My personal favorite mix-ins are white chocolate chips, Andes Chocolate, and Reese's Pieces. The overall flavor is reminiscent of a fudgey brownies and hits the spot!",
   "ingredients": [
     [
-      "1 box Betty Crocker Triple Chocolate Fudge Cake Mix",
-      "2 eggs",
-      "1/2 cup canola oil",
-      "1 cup chocolate chips or any other candy (ex: Andes)"
+      {"quantity": 1, "unitTag": "box", "ingredient": "Betty Crocker Triple Chocolate Fudge Cake Mix", "key": "cake-mix"},
+      {"quantity": 2, "unitTag": "egg", "key": "egg"},
+      {"quantity": 0.5, "unitTag": "cup", "ingredient": "canola oil", "key": "canola-oil"},
+      {"quantity": 1, "unitTag": "cup", "ingredient": "chocolate chips or any other candy (ex: Andes)", "key": "chocolate-chips"}
     ]
   ],
   "steps": [

--- a/src/assets/recipes/cinnamon-buns.json
+++ b/src/assets/recipes/cinnamon-buns.json
@@ -4,29 +4,30 @@
   "subtitle2": "This is a classic dessert in my house! The cinnamon flavor comes through beautifully without being too strong. The sweet yeasty brioche flavor balances the cinnamon flavor combined with the creamy sweet frosting. These cinnamon buns are not too sweet and warms up beautifully. The recipe itself is not too hard but will require a stand mixer and some basic dough knowledge.",
   "categories": ["Dough", "Filling", "Frosting"],
   "ingredients": [[
-    "1 cup warm milk (115 Degrees F)",
-    "2 1/2 tsp instant dry yeast",
-    "2 eggs",
-    "1/3 cup salted butter, melted and cooled",
-    "1/2 cup granulated sugar",
-    "1 tsp salt",
-    "4 1/2 cups all-purpose flour"
+    {"quantity": 1, "unitTag": "cup", "ingredient": "warm milk (115 Degrees F)", "key": "dough-milk"},
+    {"quantity": 2.5, "unitTag": "tsp", "ingredient": "instant dry yeast", "key": "dough-yeast"},
+    {"quantity": 2, "unitTag": "egg", "key": "dough-egg"},
+    {"quantity": 0.33, "unitTag": "cup", "ingredient": "salted butter, melted and cooled", "key": "dough-butter"},
+    {"quantity": 0.5, "unitTag": "cup", "ingredient": "granulated sugar", "key": "dough-sugar"},
+    {"quantity": 1, "unitTag": "tsp", "ingredient": "salt", "key": "dough-salt"},
+    {"quantity": 4, "unitTag": "cup", "ingredient": "all-purpose flour", "key": "dough-flour"},
+    {"quantity": 0.5, "unitTag": "cup", "ingredient": "more all-purpose flour (if needed)", "key": "dough-flour-extra"}
   ], [
-    "1/2 cup salted butter",
-    "1 cup packed brown sugar",
-    "2 tbsp cinnamon",
-    "1/2 cup heavy cream"
+    {"quantity": 0.5, "unitTag": "cup", "ingredient": "salted butter", "key": "filling-butter"},
+    {"quantity": 1, "unitTag": "cup", "ingredient": "packed brown sugar", "key": "filling-sugar"},
+    {"quantity": 2, "unitTag": "tbsp", "ingredient": "cinnamon", "key": "filling-cinnamon"},
+    {"quantity": 0.5, "unitTag": "cup", "ingredient": "heavy cream", "key": "filling-cream"}
   ], [
-    "1/3 cup salted butter",
-    "2 cups powdered sugar",
-    "1/2 tbsp vanilla extract"
+    {"quantity": 0.33, "unitTag": "cup", "ingredient": "salted butter", "key": "frosting-butter"},
+    {"quantity": 2, "unitTag": "cup", "ingredient": "powdered sugar", "key": "frosting-sugar"},
+    {"quantity": 0.5, "unitTag": "tbsp", "ingredient": "vanilla extract", "key": "frosting-vanilla"}
   ]],
   "steps": [
     "Pour the warm milk in the bowl of a stand mixer and sprinkle the yeast overtop.",
     "Add the eggs, butter and sugar. Mix until combined.",
-    "Add in salt and 4 cups (save the other ½ cup and add only if you need it) of flour and mix using the beater blade just until the ingredients are barely combined. Allow the mixture to rest for 5 minutes so the flour has time to soak up the liquids.",
+    "Add in salt and !dough-flour and mix using the beater blade just until the ingredients are barely combined. Allow the mixture to rest for 5 minutes so the flour has time to soak up the liquids.",
     "Scrape the dough off the beater blade and remove it. Attach the dough hook.",
-    "Beat the dough on medium speed, adding in up to ½ cup more flour if needed to form a dough. Knead for 5-7 minutes or until the dough is elastic and smooth. <i>The dough should be tacky and will still be sticking to the sides of the bowl. That's ok! Don't be tempted to add more flour at this point. We generally add about 4 ½ cups, but start with 4 cups.</i>",
+    "Beat the dough on medium speed, adding in up to !dough-flour-extra to form a dough. Knead for 5-7 minutes or until the dough is elastic and smooth. <i>The dough should be tacky and will still be sticking to the sides of the bowl. That's ok! Don't be tempted to add more flour at this point. We generally add about 4 ½ cups, but start with 4 cups.</i>",
     "Spray a large bowl with cooking spray.",
     "Use a rubber spatula to remove the dough from the mixer bowl and place it in the greased large bowl.",
     "Cover the bowl with a towel or wax paper.",
@@ -36,7 +37,7 @@
     "Flour a rolling pin and roll the dough to about a 24×15\" rectangle. (the size of the rectangle can vary it does not have to be exact!",
     "Use a rubber spatula to smooth the cinnamon filling over the whole dough rectangle.",
     "Starting on the long end, roll the dough up tightly jelly roll style.",
-    "Cut into 12 slices and place in a greased 9×13 baking pan.",
+    "Cut into !serves slices and place in a greased 9×13 baking pan.",
     "Cover the pan and allow the rolls to rise for 20 minutes or until nearly double.",
     "Preheat the oven to 375 degrees.",
     "Warm the heavy cream until the chill is off. Don’t make it hot, you just don’t want it cold. It should be warm to the touch.",

--- a/src/assets/recipes/deconstructed-elote.json
+++ b/src/assets/recipes/deconstructed-elote.json
@@ -4,22 +4,22 @@
   "subtitle2": "The first time I had elote was in Texas! Deconstructed elote makes corn easy! I take a few shortcuts that makes this recipe quick and perfect as an appetizer.",
   "ingredients": [
     [
-      "2 cups frozen corn",
-      "1 tbsp butter",
-      "1/4 cup mayo",
-      "2 tbsp chipotle pepper, jarred or canned",
-      "1 tsp fresh lime juice",
-      "1/2 tsp chili powder",
-      "1/2 tsp chipotle powder",
-      "1/2 a lime to squeeze on top",
-      "2 tsp chopped cilantro",
-      "2 tbsp cojita cheese, crumbled"
-  ]
+      {"quantity": 2, "unitTag": "cup", "ingredient": "frozen corn", "key": "corn"},
+      {"quantity": 1, "unitTag": "tbsp", "ingredient": "butter", "key": "butter"},
+      {"quantity": 0.25, "unitTag": "cup", "ingredient": "mayo", "key": "mayo"},
+      {"quantity": 2, "unitTag": "tbsp", "ingredient": "chipotle pepper, jarred or canned", "key": "chipotle-pepper"},
+      {"quantity": 1, "unitTag": "tsp", "ingredient": "fresh lime juice", "key": "lime"},
+      {"quantity": 0.5, "unitTag": "tsp", "ingredient": "chili powder", "key": "chili"},
+      {"quantity": 0.5, "unitTag": "tsp", "ingredient": "chipotle powder", "key": "chipotle-powder"},
+      {"quantity": 0.5, "unitTag": "lime", "ingredient": "to squeeze on top", "key": "lime"},
+      {"quantity": 2, "unitTag": "tsp", "ingredient": "chopped cilantro", "key": "cilantro"},
+      {"quantity": 2, "unitTag": "tbsp", "ingredient": "cojita cheese, crumbled", "key": "cojita"}
+    ]
   ],
   "steps": [
     "Heat up a pan to medium heat and melt butter. Add the frozen corn and cook until brown spots begin to appear and the corn is fully cooked through.",
     "In a bowl, mix the mayo, chipotle pepper (jarred), lime juice, chili powder, and chipotle powder. Taste and adjust with additional seasoning based on your spice tolerance.",
-    "Divide the corn into 4 separate bowls. Drizzle with the chiptole sauce. Evenly distribute the cojita cheese and cilantro on top. Squeeze fresh lime juice to taste."
+    "Divide the corn into !serves separate bowls. Drizzle with the chiptole sauce. Evenly distribute the cojita cheese and cilantro on top. Squeeze fresh lime juice to taste."
   ],
   "preptime": "10 minutes",
   "cooktime": "5 minutes",

--- a/src/assets/recipes/eggs-en-cocotte.json
+++ b/src/assets/recipes/eggs-en-cocotte.json
@@ -4,23 +4,25 @@
   "subtitle2": "Eggs en Cocotte is a soft centered egg cooked in ramekins that can have any toppings you enjoy. My personal favorite is roasted tomatoes and carmelized onions with some goat cheese. They are easy to prepare in advance making it a great breakfast on the weekends or perfect for when I have friends and family over.",
   "ingredients": [
     [
-      "4 eggs",
-      "3 tsp of olive oil",
-      "4 tbsp of goat cheese",
-      "2 small white or yellow onions, sliced length-wise",
-      "16 cherry tomatoes, sliced lengthwise into halves",
-      "4 teaspoons of milk",
-      "salt",
-      "pepper",
-      "4 ramekins"
+      {"quantity": 4, "unitTag": "egg", "key": "egg"},
+      {"quantity": 2, "unitTag": "tsp", "ingredient": "olive oil", "key": "olive-oil"},
+      {"quantity": 1, "unitTag": "tsp", "ingredient": "of olive oil", "key": "olive-oil-split", "hidden": true},
+      {"quantity": 1, "unitTag": "tsp", "ingredient": "of olive oil or butter", "key": "olive-oil"},
+      {"quantity": 4, "unitTag": "tbsp", "ingredient": "of goat cheese", "key": "goat-cheese"},
+      {"quantity": 2, "unitTag": "small white or yellow onion", "ingredient": "sliced length-wise", "key": "onion"},
+      {"quantity": 16, "unitTag": "cherry tomato", "ingredient": "sliced lengthwise into halves", "key": "cherry-tomato"},
+      {"quantity": 4, "unitTag": "tsp", "ingredient": "of milk", "key": "milk"},
+      {"ingredient": "salt", "key": "salt"},
+      {"ingredient": "pepper", "key": "pepper"},
+      {"quantity": 4, "unitTag": "ramekin", "key": "ramekin"}
     ]
   ],
   "steps": [
     "Pre-heat the oven to 400°F. Line the baking dish with the dish towel (optional). The dishtowel will keep the ramekins from sliding when you carry the baking dish.",
-    "Place sliced cherry tomatoes on a baking sheet and coat with 1 tsp of olive oil. Bake for 20 - 25 minutes or until they have started to wrinkle and begin to brown.",
+    "Place sliced cherry tomatoes on a baking sheet and coat with !olive-oil-split. Bake for 20 - 25 minutes or until they have started to wrinkle and begin to brown.",
     "Set the oven to 375°F.",
-    "In a cast iron pan, add the onions and 1 tsp of olive oil. Cook on medium heat. Stir occasionally, until the onion are golden brown and have completely softened.",
-    "Rub the insides of the ramekins with butter or olive oil. Distribute the roasted tomatoes and carmelized onions evenly between all 4 ramekins.",
+    "In a cast iron pan, add the onions and !olive-oil-split. Cook on medium heat. Stir occasionally, until the onion are golden brown and have completely softened.",
+    "Rub the insides of the ramekins with butter or olive oil. Distribute the roasted tomatoes and carmelized onions evenly between all !ramekin.",
     "Create a small well in the bottom of each ramekin. This will be where the yolk will nest.",
     "Crack one egg into each ramekin.",
     "Sprinkle each egg with a pinch of salt and pepper. If you'd like a richer baked egg and some extra insurance against the yolk drying out in the oven, add a spoonful of milk to each ramekin on top of the yolk.",

--- a/src/assets/recipes/eggs-en-cocotte.json
+++ b/src/assets/recipes/eggs-en-cocotte.json
@@ -7,14 +7,14 @@
       {"quantity": 4, "unitTag": "egg", "key": "egg"},
       {"quantity": 2, "unitTag": "tsp", "ingredient": "olive oil", "key": "olive-oil"},
       {"quantity": 1, "unitTag": "tsp", "ingredient": "of olive oil", "key": "olive-oil-split", "hidden": true},
-      {"quantity": 1, "unitTag": "tsp", "ingredient": "of olive oil or butter", "key": "olive-oil"},
       {"quantity": 4, "unitTag": "tbsp", "ingredient": "of goat cheese", "key": "goat-cheese"},
       {"quantity": 2, "unitTag": "small white or yellow onion", "ingredient": "sliced length-wise", "key": "onion"},
       {"quantity": 16, "unitTag": "cherry tomato", "ingredient": "sliced lengthwise into halves", "key": "cherry-tomato"},
       {"quantity": 4, "unitTag": "tsp", "ingredient": "of milk", "key": "milk"},
       {"ingredient": "salt", "key": "salt"},
       {"ingredient": "pepper", "key": "pepper"},
-      {"quantity": 4, "unitTag": "ramekin", "key": "ramekin"}
+      {"quantity": 4, "unitTag": "ramekin", "key": "ramekin"},
+      {"ingredient": "extra olive oil or butter for ramekins", "key": "extra-ingredients"}
     ]
   ],
   "steps": [

--- a/src/assets/recipes/eton-mess.json
+++ b/src/assets/recipes/eton-mess.json
@@ -4,12 +4,12 @@
     "subtitle2": "This is a classic British treat! Inspired by my obsession with the Great British Bake Off. The recipe itself is easy to make and can be prepped in advance and assembled in minutes. It keeps well up to 3 days. You will need an electric whisk as this recipe does have meringue involved.",
     "ingredients": [
         [
-            "2 large egg whites",
-            "120g granulated sugar",
-            "500g strawberries, hulled and roughly chopped",
-            "1 cup heavy cream",
-            "1 teaspoon powder sugar",
-            "1/2 cup raspberries"
+            {"quantity": 2, "unitTag": "large egg white", "key": "egg-white"},
+            {"quantity": 120, "unitTag": "gram", "ingredient": "granulated sugar", "key": "granulated-sugar"},
+            {"quantity": 500, "unitTag": "gram", "ingredient": "strawberries, hulled and roughly chopped", "key": "strawberries"},
+            {"quantity": 1, "unitTag": "cup", "ingredient": "heavy cream", "key": "cream"},
+            {"quantity": 1, "unitTag": "tsp", "ingredient": "powdered sugar", "key": "powdered-sugar"},
+            {"quantity": 0.5, "unitTag": "cup", "ingredient": "raspberries", "key": "raspberries"}
         ]
     ],
     "steps": [

--- a/src/assets/recipes/jalapeno-poppers.json
+++ b/src/assets/recipes/jalapeno-poppers.json
@@ -1,18 +1,18 @@
 {
-  "title": "Puff Pastry Jalapeno Poppers",
+  "title": "Puff Pastry Jalapeño Poppers",
   "subtitle": "This is a delicious treat that is spicy, creamy, and buttery! Perfect for any party. Simple to make, and heats up well.",
   "subtitle2": "Puff pastry Jalapeno Popper have the classic flavors of shredded cheese, spicy jalapenos, and cream cheese all wrapped up in a tender and flaky puff pastry! They are a portable appetizer that is perfect for game days, or any party!",
   "ingredients": [
     [
-      "6-7 jalapeño peppers",
-      "1 package (8 ounces) cream cheese, room temperature",
-      "1 cup (8 ounces) shredded jack cheese",
-      "2 green onions, chopped",
-      "1/2 teaspoon salt",
-      "1/4 teaspoon black pepper",
-      "1/2 teaspoon garlic powder",
-      "1 package puff pastry dough (typically use pepperidge farm)",
-      "1 egg, beaten"
+      {"quantity": 6, "unitTag": "jalapeno pepper", "ingredient": "(approximately)", "key": "jalapeno"},
+      {"quantity": 1, "unitTag": "package", "ingredient": "(8 ounces each) cream cheese, room temperature", "key": "cream-cheese"},
+      {"quantity": 1, "unitTag": "cup", "ingredient": "shredded jack cheese", "key": "jack-cheese"},
+      {"quantity": 2, "unitTag": "green onion", "ingredient": "chopped", "key": "onion"},
+      {"quantity": 0.5, "unitTag": "tsp", "ingredient": "salt", "key": "salt"},
+      {"quantity": 0.25, "unitTag": "tsp", "ingredient": "black pepper", "key": "pepper"},
+      {"quantity": 0.5, "unitTag": "tsp", "ingredient": "garlic powder", "key": "garlic"},
+      {"quantity": 1, "unitTag": "package", "ingredient": "puff pastry dough (typically use pepperidge farm)", "key": "dough"},
+      {"quantity": 1, "unitTag": "egg", "ingredient": "beaten", "key": "egg"}
   ]
   ],
   "steps": [

--- a/src/assets/recipes/mushroom-miso-soup.json
+++ b/src/assets/recipes/mushroom-miso-soup.json
@@ -4,22 +4,22 @@
   "subtitle2": "This is my go to soup to make when I'm not feeling well! The miso base, spices, and vegetables is the perfect combination to kick out a cold. Feel free to sub out any of the veggies for whatever vegetables you have in the fridge. I personally get my miso paste from Sprout's.",
   "ingredients": [
     [
-      "2 tbsp of white miso paste",
-      "3 cups water",
-      "4 cloves of garlic",
-      "1 tsp ginger, minced",
-      "1 small box of mushrooms, sliced",
-      "1 cup frozen spinach or any leafy green",
-      "1 large carrot, diced",
-      "1/2 cup frozen peas",
-      "1/2 cup frozen corn", 
-      "1 tbsp olive oil",
-      "1 lime, juiced",
-      "2 tsp siracha",
-      "3 tsp soy sauce",
-      "2 tsp rice vinegar",
-      "pepper",
-      "salt"
+      {"quantity": 2, "unitTag": "tbsp", "ingredient": "of white miso paste", "key": "miso"},
+      {"quantity": 3, "unitTag": "cup", "ingredient": "water", "key": "water"},
+      {"quantity": 4, "unitTag": "clove", "ingredient": "of garlic", "key": "garlic"},
+      {"quantity": 1, "unitTag": "tsp", "ingredient": "ginger, minced", "key": "ginger"},
+      {"quantity": 1, "unitTag": "small box", "ingredient": "of mushrooms, sliced", "key": "mushrooms"},
+      {"quantity": 1, "unitTag": "cup", "ingredient": "frozen spinach or any leafy green", "key": "spinach"},
+      {"quantity": 1, "unitTag": "large carrot", "ingredient": "(diced)", "key": "carrot"},
+      {"quantity": 0.5, "unitTag": "cup", "ingredient": "frozen peas", "key": "peas"},
+      {"quantity": 0.5, "unitTag": "cup", "ingredient": "frozen corn", "key": "corn"},
+      {"quantity": 1, "unitTag": "tbsp", "ingredient": "olive oil", "key": "olive-oil"},
+      {"quantity": 1, "unitTag": "lime", "ingredient": "(juiced)", "key": "lime"},
+      {"quantity": 2, "unitTag": "tsp", "ingredient": "siracha", "key": "siracha"},
+      {"quantity": 3, "unitTag": "tsp", "ingredient": "soy sauce", "key": "soy"},
+      {"quantity": 2, "unitTag": "tsp", "ingredient": "rice vinegar", "key": "vinegar"},
+      {"ingredient": "salt", "key": "salt"},
+      {"ingredient": "pepper", "key": "pepper"}
     ]
   ],
   "steps": [

--- a/src/assets/recipes/orange-cake.json
+++ b/src/assets/recipes/orange-cake.json
@@ -8,23 +8,23 @@
   ],
   "ingredients": [
     [
-      "2 and 1/2 cups flour",
-      "1 and 3/4 cup sugar",
-      "1 and 1/2 teaspoon baking soda",
-      "1 teaspoon baking powder",
-      "3/4 teaspoon salt",
-      "1 cup olive oil",
-      "1 cup fresh orange juice",
-      "3 eggs",
-      "1 cup sour cream",
-      "2 teaspoons orange zest"
+      {"quantity": 2.5, "unitTag": "cup", "ingredient": "flour", "key": "cake-flour"},
+      {"quantity": 1.75, "unitTag": "cup", "ingredient": "sugar", "key": "cake-sugar"},
+      {"quantity": 1.5, "unitTag": "tsp", "ingredient": "baking soda", "key": "cake-baking-soda"},
+      {"quantity": 1, "unitTag": "tsp", "ingredient": "baking powder", "key": "cake-baking-powder"},
+      {"quantity": 0.75, "unitTag": "tsp", "ingredient": "salt", "key": "cake-salt"},
+      {"quantity": 1, "unitTag": "cup", "ingredient": "olive oil", "key": "cake-olive-oil"},
+      {"quantity": 1, "unitTag": "cup", "ingredient": "fresh orange juice", "key": "cake-orange-juice"},
+      {"quantity": 3, "unitTag": "egg", "key": "cake-egg"},
+      {"quantity": 1, "unitTag": "cup", "ingredient": "sour cream", "key": "cake-sour-cream"},
+      {"quantity": 2, "unitTag": "tsp", "ingredient": "orange zest", "key": "cake-orange-zest"}
     ], [
-      "1 and 1/2 cup butter, softened",
-      "12 oz of cream cheese, softened",
-      "6 cups powdered sugar",
-      "2 teaspoon orange zest",
-      "3 tablespoons fresh orange juice",
-      "1 teaspoon vanilla extract"
+      {"quantity": 1.5, "unitTag": "cup", "ingredient": "butter, softened", "key": "frosting-butter"},
+      {"quantity": 12, "unitTag": "oz", "ingredient": "cream cheese, softened", "key": "frosting-cheese"},
+      {"quantity": 6, "unitTag": "cup", "ingredient": "powdered sugar", "key": "frosting-sugar"},
+      {"quantity": 2, "unitTag": "tsp", "ingredient": "orange zest", "key": "frosting-orange-zest"},
+      {"quantity": 3, "unitTag": "tbsp", "ingredient": "fresh orange juice", "key": "frosting-orange-juice"},
+      {"quantity": 1, "unitTag": "tsp", "ingredient": "vanilla extract", "key": "frosting-vanilla"}
     ]
   ],
   "steps": [

--- a/src/assets/recipes/psl.json
+++ b/src/assets/recipes/psl.json
@@ -4,11 +4,11 @@
   "subtitle2": "This drink is perfect for the fall season! It is simple to make and tastes superior to any store bought syrup or drink.",
   "ingredients": [
     [
-      "2 tbsp Libby's Pumpkin Pie Mix",
-      "1/8 teaspoon cinnamon",
-      "whipped cream",
-      "1 cup milk",
-      "1 espresso shot"
+      {"quantity": 2, "unitTag": "tbsp", "ingredient": "Libby's Pumpkin Pie Mix", "key": "pie-mix"},
+      {"quantity": 0.125, "unitTag": "tsp", "ingredient": "cinnamon", "key": "cinnamon"},
+      {"ingredient": "whipped cream", "key": "whipped-cream"},
+      {"quantity": 1, "unitTag": "cup", "ingredient": "milk", "key": "milk"},
+      {"quantity": 1, "unitTag": "espresso shot", "key": "espresso"}
     ]
   ],
   "steps": [
@@ -20,5 +20,6 @@
   "preptime": "5 minutes",
   "cooktime": "2 minutes",
   "totaltime": "7 minutes",
-  "serves": 1
+  "serves": 1,
+  "indivisible": true
 }

--- a/src/assets/recipes/pumpkin-mascarpone-pie.json
+++ b/src/assets/recipes/pumpkin-mascarpone-pie.json
@@ -4,15 +4,15 @@
   "subtitle2": "Spend just minutes mixing the mascarpone cheese and pumpkin puree filling together with fall spices, then pour into a prepared pie crust, and bake. The mascarpone makes this pie extra creamy and dreamy while the spices offset it. This pie is not too sweet which makes it incredibly addicting.",
   "ingredients": [
     [
-      "1 (13.5 oz) can pumpkin puree",
-      "1 cup mascarpone cheese",
-      "1/4 cup brown sugar",
-      "1 teaspoon pumpkin pie spice",
-      "1 teaspoon vanilla extract",
-      "1 tablespoon fresh lemon juice",
-      "2 large eggs",
-      "1/4 teaspoon salt",
-      "1 single 9 inch pie crust, homemade or store-bought"
+      {"quantity": 1, "unitTag": "can", "ingredient": "(13.5 oz each) pumpkin puree", "key": "pumpkin-puree"},
+      {"quantity": 1, "unitTag": "cup", "ingredient": "mascarpone cheese", "key": "cheese"},
+      {"quantity": 0.25, "unitTag": "cup", "ingredient": "brown sugar", "key": "sugar"},
+      {"quantity": 1, "unitTag": "tsp", "ingredient": "pumpkin pie spice", "key": "spice"},
+      {"quantity": 1, "unitTag": "tsp", "ingredient": "vanilla extract", "key": "vanilla"},
+      {"quantity": 1, "unitTag": "tbsp", "ingredient": "fresh lemon juice", "key": "lemon"},
+      {"quantity": 2, "unitTag": "large egg", "key": "egg"},
+      {"quantity": 0.25, "unitTag": "tsp", "ingredient": "salt", "key": "salt"},
+      {"quantity": 1, "unitTag": "single 9 inch pie crust", "ingredient": "(homemade or store-bought)", "key": "crust"}
      ]
   ],
   "steps": [
@@ -24,5 +24,6 @@
   "preptime": "10 min",
   "cooktime": "1 hr",
   "totaltime": "1 hr 30 min",
-  "serves": 12
+  "serves": 12,
+  "indivisible": true
 }

--- a/src/assets/recipes/sugar-cookies.json
+++ b/src/assets/recipes/sugar-cookies.json
@@ -8,20 +8,20 @@
   ],
   "ingredients": [
     [
-      "2 and 1/4 cups all-purpose flour (spoon & leveled), plus more as needed for rolling and work surface",
-      "1/2 teaspoon baking powder",
-      "1/4 teaspoon salt",
-      "3/4 cup unsalted butter, softened to room temperature",
-      "3/4 cup granulated sugar",
-      "1 large egg",
-      "2 teaspoons pure vanilla extract",
-      "1/4 or 1/2 teaspoon almond extract (optional, but makes the flavor outstanding)"
+      {"quantity": 2.25, "unitTag": "cup", "ingredient": "all-purpose flour (spoon & leveled), plus more as needed for rolling and work surface", "key": "cookies-flour"},
+      {"quantity": 0.5, "unitTag": "tsp", "ingredient": "baking powder", "key": "cookies-baking-powder"},
+      {"quantity": 0.25, "unitTag": "tsp", "ingredient": "salt", "key": "cookies-salt"},
+      {"quantity": 0.75, "unitTag": "cup", "ingredient": "unsalted butter, softened to room temperature", "key": "cookies-butter"},
+      {"quantity": 0.75, "unitTag": "cup", "ingredient": "granulated sugar", "key": "cookies-sugar"},
+      {"quantity": 1, "unitTag": "large egg", "key": "cookies-egg"},
+      {"quantity": 2, "unitTag": "tsp", "ingredient": "pure vanilla extract", "key": "cookies-vanilla"},
+      {"quantity": 0.25, "unitTag": "tsp", "ingredient": "(or double) almond extract (optional, but makes the flavor outstanding)", "key": "cookies-almond"}
     ], [
-      "3 cups confectioners’ sugar",
-      "1/2 teaspoon pure vanilla extract",
-      "2 teaspoons light corn syrup",
-      "4.5–5 Tablespoonsroom temperature water",
-      "pinch of salt"
+      {"quantity": 3, "unitTag": "cup", "ingredient": "confectioners’ sugar", "key": "icing-sugar"},
+      {"quantity": 0.5, "unitTag": "tsp", "ingredient": "pure vanilla extract", "key": "icing-vanilla"},
+      {"quantity": 2, "unitTag": "tsp", "ingredient": "light corn syrup", "key": "icing-corn-syrup"},
+      {"quantity": 4.5, "unitTag": "tbsp", "ingredient": "(or more) room temperature water", "key": "icing-water"},
+      {"ingredient": "pinch of salt", "key": "icing-salt"}
     ]
   ],
   "steps": [
@@ -33,7 +33,7 @@
     "Lightly dust one of the rolled-out doughs with flour. Place a piece of parchment on top. (This prevents sticking.) Place the 2nd rolled-out dough on top. Cover with plastic wrap or aluminum foil, then refrigerate for at least 1-2 hours and up to 2 days.",
     "Once chilled, preheat oven to 350 F. Line 2-3 large baking sheets with parchment paper or silicone baking mats. Carefully remove the top dough piece from the refrigerator. If it’s sticking to the bottom, run your hand under it to help remove it. Using a cookie cutter, cut the dough into shapes. Re-roll the remaining dough and continue cutting until all is used. Repeat with 2nd piece of dough. (Note: It doesn’t seem like a lot of dough, but you get a lot of cookies from the dough scraps you re-roll.)",
     "Arrange cookies on baking sheets 3 inches apart. Bake for 11-12 minutes or until lightly browned around the edges. If your oven has hot spots, rotate the baking sheet halfway through bake time. Allow cookies to cool on the baking sheet for 5 minutes then transfer to a wire rack to cool completely before decorating.",
-    "For the frosting, Using a fork, stir the confectioners’ sugar, vanilla, corn syrup, and 4.5 Tablespoons (67ml) of water together in a medium bowl. It will be very thick and almost impossible to stir. Switch to a whisk and whisk in 1/2 Tablespoon (8ml) of water. If you lift the whisk and let the icing drizzle back into the bowl, the ribbon of icing will hold shape for a few seconds before melting back into the icing. That is when you know it’s the right consistency and is ready to use. If it’s too thick (sometimes it is), whisk in another 1/2 Tablespoon (8ml) of water or a little more until you reach the consistency.",
+    "For the frosting, Using a fork, stir the confectioners’ sugar, vanilla, corn syrup, and !icing-water together in a medium bowl. It will be very thick and almost impossible to stir. Switch to a whisk and whisk in 1/2 Tablespoon (8ml) of water. If you lift the whisk and let the icing drizzle back into the bowl, the ribbon of icing will hold shape for a few seconds before melting back into the icing. That is when you know it’s the right consistency and is ready to use. If it’s too thick (sometimes it is), whisk in another 1/2 Tablespoon (8ml) of water or a little more until you reach the consistency.",
     "If desired, stir in gel food coloring. You can pour some icing into different bowls if using multiple colors. When tinting icing, only use 1-2 drops at first, stir it in, then add more as needed to reach your desired color. Remember, color darkens as icing dries.",
     "Decorate the cooled cookies with royal icing or easy glaze icing. Feel free to tint either icing with gel food coloring. See post above for recommended decorating tools. No need to cover the decorated cookies as you wait for the icing to set. If it’s helpful, decorate the cookies directly on a baking sheet so you can stick the entire baking sheet in the refrigerator to help speed up the icing setting.",
     "Enjoy cookies right away or wait until the icing sets to serve them. Once the icing has set, these cookies are great for gifting or for sending. Plain or decorated cookies stay soft for about 5 days when covered tightly at room temperature. For longer storage, cover and refrigerate for up to 10 days."

--- a/src/assets/recipes/turkish-eggs.json
+++ b/src/assets/recipes/turkish-eggs.json
@@ -4,14 +4,14 @@
   "subtitle2": "This is a week night classic in my house! Turkish eggs is a simple recipe that comes together in a short amount of time. This recipe also scales up well, so it easy to make for the entire family!",
   "ingredients": [
     [
-      "4 eggs",
-      "1 cup greek yogurt",
-      "1 clove of garlic",
-      "1 teaspoon dill",
-      "1 teaspoon lemon juice",
-      "flaky sea salt",
-      "2 tbsp butter",
-      "1 - 2 teaspoons chili powder"
+      {"quantity": 4, "unitTag": "egg", "key": "egg"},
+      {"quantity": 1, "unitTag": "cup", "ingredient": "greek yogurt", "key": "yogurt"},
+      {"quantity": 1, "unitTag": "clove", "ingredient": "of garlic", "key": "garlic"},
+      {"quantity": 1, "unitTag": "tsp", "ingredient": "dill", "key": "dill"},
+      {"quantity": 1, "unitTag": "tsp", "ingredient": "lemon juice", "key": "lemon-juice"},
+      {"ingredient": "flaky sea salt", "key": "sea-salt"},
+      {"quantity": 2, "unitTag": "tbsp", "ingredient": "butter", "key": "butter"},
+      {"quantity": 0, "unitTag": "tsp", "ingredient": "(or double) chili powder", "key": "chili-powder"}
     ]
   ],
   "steps": [
@@ -19,7 +19,7 @@
     "In a bowl mix the greek yogurt, lemon juice, a pinch of salt, and minced garlic.",
     "In a small pan, heat the butter until it is browned. Take off from heat. Add the chili powder and mix. Set aside.",
     "Add the eggs to the boiling water. Cook for 5 minutes. Immediately take out of boiling water and put in ice cold water. Peel the eggs and set aside.",
-    "On two plates, split the yogurt mixture. Make a swirl and for the eggs to sit in. Place the 2 eggs on top of the yogurt. Drizzle the butter chili oil on top of the eggs. Top with dill and flakey sea salt.",
+    "On two plates, split the yogurt mixture. Make a swirl and for the eggs to sit in. Place the !egg on top of the yogurt. Drizzle the butter chili oil on top of the eggs. Top with dill and flakey sea salt.",
     "Eat immediately with toast points or just on it's own."
   ],
   "preptime": "10 minutes",

--- a/src/assets/recipes/turkish-eggs.json
+++ b/src/assets/recipes/turkish-eggs.json
@@ -19,7 +19,7 @@
     "In a bowl mix the greek yogurt, lemon juice, a pinch of salt, and minced garlic.",
     "In a small pan, heat the butter until it is browned. Take off from heat. Add the chili powder and mix. Set aside.",
     "Add the eggs to the boiling water. Cook for 5 minutes. Immediately take out of boiling water and put in ice cold water. Peel the eggs and set aside.",
-    "On two plates, split the yogurt mixture. Make a swirl and for the eggs to sit in. Place the !egg on top of the yogurt. Drizzle the butter chili oil on top of the eggs. Top with dill and flakey sea salt.",
+    "Between the plates, split the yogurt mixture. Make a swirl and for the eggs to sit in. Place the eggs evenly among the plates on top of the yogurt. Drizzle the butter chili oil on top of the eggs. Top with dill and flakey sea salt.",
     "Eat immediately with toast points or just on it's own."
   ],
   "preptime": "10 minutes",

--- a/src/assets/recipes/veggie-dumplings.json
+++ b/src/assets/recipes/veggie-dumplings.json
@@ -10,35 +10,35 @@
   ],
   "ingredients": [
     [
-      "2 1/2 cups all purpose flour",
-      "1/2 tsp salt",
-      "2/3 cup hot water",
-      "all-purpose flour for dusting"
+      {"quantity": 2.5, "unitTag": "cup", "ingredient": "all purpose flour", "key": "wrapper-flour"},
+      {"quantity": 0.5, "unitTag": "tsp", "ingredient": "salt", "key": "wrapper-salt"},
+      {"quantity": 0.67, "unitTag": "cup", "ingredient": "hot water", "key": "wrapper-water"},
+      {"ingredient": "all-purpose flour for dusting", "key": "wrapper-flour-dusting"}
     ],
     [
-      "1-2 tbsp sesame oil",
-      "2 cloves garlic minced",
-      "1 tbsp ginger minced",
-      "1 onion diced",
-      "1 carrot shredded",
-      "7 oz mushrooms",
-      "1/2 stick leek",
-      "7 oz cabbage",
-      "2 tbsp soy sauce",
-      "1 tbsp rice vinegar",
-      "salt and pepper to taste",
-      "1 tsp siracha"
+      {"quantity": 1, "unitTag": "tbsp", "ingredient": "(or double) sesame oil", "key": "filling-sesame-oil"},
+      {"quantity": 2, "unitTag": "clove", "ingredient": "garlic minced", "key": "filling-garlic"},
+      {"quantity": 1, "unitTag": "tbsp", "ingredient": "ginger minced", "key": "filling-ginger"},
+      {"quantity": 1, "unitTag": "onion", "ingredient": "diced", "key": "filling-onion"},
+      {"quantity": 1, "unitTag": "carrot", "ingredient": "shredded", "key": "filling-carrot"},
+      {"quantity": 7, "unitTag": "oz", "ingredient": "mushrooms", "key": "filling-mushrooms"},
+      {"quantity": 0.5, "unitTag": "stick", "ingredient": "leek", "key": "filling-leek"},
+      {"quantity": 7, "unitTag": "oz", "ingredient": "cabbage", "key": "filling-cabbage"},
+      {"quantity": 2, "unitTag": "tbsp", "ingredient": "soy sauce", "key": "filling-soy"},
+      {"quantity": 1, "unitTag": "tbsp", "ingredient": "rice vinegar", "key": "filling-vinegar"},
+      {"ingredient": "salt and pepper to taste", "key": "filling-salt-pepper"},
+      {"quantity": 1, "unitTag": "tsp", "ingredient": "siracha", "key": "filling-siracha"}
     ],
     [
-      "3 tbsp soy sauce",
-      "1 tbsp rice vinegar",
-      "1 tbsp agave syrup",
-      "1/4 tsp sesame oil",
-      "1/2 tsp siracha"
+      {"quantity": 3, "unitTag": "tbsp", "ingredient": "soy sauce", "key": "sauce-soy"},
+      {"quantity": 1, "unitTag": "tbsp", "ingredient": "rice vinegar", "key": "sauce-vinegar"},
+      {"quantity": 1, "unitTag": "tbsp", "ingredient": "agave syrup", "key": "sauce-agave"},
+      {"quantity": 0.25, "unitTag": "tsp", "ingredient": "sesame oil", "key": "sauce-sesame-oil"},
+      {"quantity": 0.5, "unitTag": "tsp", "ingredient": "siracha", "key": "sauce-siracha"}
     ],
     [
-      "sesame seeds",
-      "green onions, finely sliced"
+      {"ingredient": "sesame seeds", "key": "garnish-sesame"},
+      {"ingredient": "green onions, finely sliced", "key": "garnish-onion"}
     ]
   ],
   "steps": [
@@ -52,7 +52,7 @@
     "Set aside to cool.",
     "Add 1 heaped teaspoon of filling to the center of the dumpling wrapper. Brush the edges with water and fold the dumpling creating hand fan pattern or as desired. Make sure to seal the seams.",
     "Repeat until the wrappers are used up.",
-    "Heat the oil in pan over medium heat. Add the gyoza and fry for 2-3 min or until the bottoms are slightly browned. Pour in 1/4 cup of water and cover with a lid. Steam for 7-8 minutes or until the water has evaporated.",
+    "Heat the oil in pan over medium heat. Add the gyoza and fry for 2-3 min or until the bottoms are slightly browned. Pour in ¼ cup of water and cover with a lid. Steam for 7-8 minutes or until the water has evaporated.",
     "For the dipping sauce, mix all the ingredients.",
     "Top dumplings with sesame seeds and green onions before serving."
     ],

--- a/src/atom/RecipeCard/index.tsx
+++ b/src/atom/RecipeCard/index.tsx
@@ -1,21 +1,23 @@
 import React, { useCallback, useEffect, useState } from 'react'
-import Card from '@mui/material/Card';
-import CardContent from '@mui/material/CardContent';
-import Grid from '@mui/material/Grid';
-import ThemeProvider from '@mui/styles/ThemeProvider'
-import Typography from '@mui/material/Typography';
-
-import { theme } from '../../utils/theme'
-import Box from '@mui/material/Box';
-import Switch from '@mui/material/Switch';
-import FormGroup from '@mui/material/FormGroup';
-import FormControlLabel from '@mui/material/FormControlLabel';
-import Tooltip from '@mui/material/Tooltip';
-import Snackbar from '@mui/material/Snackbar';
 import Alert from '@mui/material/Alert';
 import AlertTitle from '@mui/material/AlertTitle';
-import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
+import Box from '@mui/material/Box';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import FormGroup from '@mui/material/FormGroup';
+import Grid from '@mui/material/Grid';
+import Snackbar from '@mui/material/Snackbar';
+import Switch from '@mui/material/Switch';
+import ThemeProvider from '@mui/styles/ThemeProvider'
 import ToggleButton from '@mui/material/ToggleButton';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+
+import Ingredient from '../../utils/ingredient';
+import { generateCategories, generateSteps } from '../../utils/RecipeCardHelpers';
+import { theme } from '../../utils/theme'
 
 type Props = {
     icon: string
@@ -25,76 +27,10 @@ type Props = {
     preptime: string
     cooktime: string
     totaltime: string
-    ingredients: string[][]
+    ingredients: Ingredient[][]
     categories?: string[]
     steps: string[]
-}
-
-const generateCategories = (ingredients: string[][], categories?: string[]) => {
-    if (categories) {
-        let retval: JSX.Element[] = []
-        let end = Math.min(categories.length, ingredients.length)
-        for (let i = 0; i < end; ++i) {
-            retval.push((
-                <React.Fragment key={categories[i]}>
-                    <Grid item xs={1}>
-                    </Grid>
-
-                    <Grid item xs={10}>
-                        <Typography sx={{
-                            fontFamily: 'Karla',
-                            fontWeight: 700,
-                            color: 'black',
-                            marginTop: theme.spacing(4)
-                        }}
-                            gutterBottom
-                            variant="body1"
-                            component="div">
-                            {categories[i]}
-                        </Typography>
-
-                        <ul>
-                            {ingredients[i].map(ingredient => (
-                                <li key={ingredient} dangerouslySetInnerHTML={{ __html: ingredient }} style={{
-                                    fontFamily: 'Karla',
-                                    color: 'black',
-                                    fontWeight: 500,
-                                    fontSize: theme.spacing(4),
-                                }} />
-                            ))}
-                        </ul>
-                    </Grid>
-
-                    <Grid item xs={1}>
-                    </Grid>
-                </React.Fragment>
-            ))
-        }
-        return retval
-    } else {
-        return ingredients.map(ingredients => (
-            <React.Fragment key={ingredients.join(',')}>
-                <Grid item xs={1}>
-                </Grid>
-
-                <Grid item xs={10}>
-                    <ul>
-                        {ingredients.map(ingredient => (
-                            <li key={ingredient} dangerouslySetInnerHTML={{ __html: ingredient }} style={{
-                                fontFamily: 'Karla',
-                                color: 'black',
-                                fontWeight: 500,
-                                fontSize: theme.spacing(4),
-                            }} />
-                        ))}
-                    </ul>
-                </Grid>
-
-                <Grid item xs={1}>
-                </Grid>
-            </React.Fragment>
-        ))
-    }
+    indivisible?: boolean
 }
 
 interface ChromiumNavigator extends Navigator {
@@ -161,11 +97,11 @@ const RecipeCard = (props: Props) => {
     const handleMultiplier = (
         event: React.MouseEvent<HTMLElement>,
         newMultiplier: number | null,
-      ) => {
+    ) => {
         if (newMultiplier !== null) {
-          setMultiplier(newMultiplier);
+            setMultiplier(newMultiplier);
         }
-      };
+    };
 
     return (
         <ThemeProvider theme={theme}>
@@ -216,12 +152,12 @@ const RecipeCard = (props: Props) => {
                                     exclusive
                                     onChange={handleMultiplier}
                                     aria-label="recipe multiplier"
-                                    sx={{p: theme.spacing(2.5)}}
+                                    sx={{ p: theme.spacing(2.5) }}
                                     color='primary'
                                 >
-                                    <ToggleButton value={1/2} aria-label="one half times">
+                                    {!props.indivisible && <ToggleButton value={1 / 2} aria-label="one half times">
                                         <Typography sx={{ fontWeight: 900 }}>½×</Typography>
-                                    </ToggleButton>
+                                    </ToggleButton>}
                                     <ToggleButton value={1} aria-label="one times">
                                         <Typography sx={{ fontWeight: 900 }}>1×</Typography>
                                     </ToggleButton>
@@ -319,53 +255,9 @@ const RecipeCard = (props: Props) => {
                             <Grid item xs={1}>
                             </Grid>
 
-                            {generateCategories(props.ingredients, props.categories)}
+                            {generateCategories(multiplier, props.ingredients, props.categories)}
 
-                            <Grid item xs={1}>
-                            </Grid>
-
-                            <Grid item xs={10}>
-                                <Typography sx={{
-                                    fontFamily: 'Jost',
-                                    fontWeight: 700,
-                                    color: 'black',
-                                    marginTop: theme.spacing(8)
-                                }}
-                                    gutterBottom
-                                    variant="body1"
-                                    component="div">
-                                    Steps
-                                </Typography>
-                            </Grid>
-
-                            <Grid item xs={1}>
-                            </Grid>
-
-
-                            <Grid item xs={1}>
-                            </Grid>
-
-                            <Grid item xs={10}>
-
-
-
-                                <ol>
-                                    {props.steps.map(step => (
-                                        <li key={step} dangerouslySetInnerHTML={{ __html: step }} style={{
-                                            fontFamily: 'Karla',
-                                            color: 'black',
-                                            fontWeight: 500,
-                                            fontSize: theme.spacing(4),
-                                        }} />
-                                    ))}
-                                </ol>
-
-                            </Grid>
-
-                            <Grid item xs={1}>
-                            </Grid>
-
-
+                            {generateSteps(props.steps, multiplier, props.ingredients, props.serves)}
 
                         </Grid>
 

--- a/src/atom/RecipeCard/index.tsx
+++ b/src/atom/RecipeCard/index.tsx
@@ -14,6 +14,8 @@ import Tooltip from '@mui/material/Tooltip';
 import Snackbar from '@mui/material/Snackbar';
 import Alert from '@mui/material/Alert';
 import AlertTitle from '@mui/material/AlertTitle';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
+import ToggleButton from '@mui/material/ToggleButton';
 
 type Props = {
     icon: string
@@ -102,6 +104,7 @@ interface ChromiumNavigator extends Navigator {
 const RecipeCard = (props: Props) => {
     const [wakeLock, setWakeLock] = useState<any>(null)
     const [cookMode, setCookMode] = useState(false)
+    const [multiplier, setMultiplier] = useState(1)
 
     const [cookModeSuccessAlertOpen, setCookModeSuccessAlertOpen] = useState(false)
     const [cookModeWarningAlertOpen, setCookModeWarningAlertOpen] = useState(false)
@@ -155,6 +158,15 @@ const RecipeCard = (props: Props) => {
         setCookModeWarningAlertOpen(false);
     };
 
+    const handleMultiplier = (
+        event: React.MouseEvent<HTMLElement>,
+        newMultiplier: number | null,
+      ) => {
+        if (newMultiplier !== null) {
+          setMultiplier(newMultiplier);
+        }
+      };
+
     return (
         <ThemeProvider theme={theme}>
             <Grid container justifyContent='center' sx={{ marginTop: theme.spacing(10) }}>
@@ -196,8 +208,31 @@ const RecipeCard = (props: Props) => {
                                     gutterBottom
                                     variant="body1"
                                     component="div">
-                                    Serves {props.serves}
+                                    Serves {props.serves * multiplier}
                                 </Typography>
+
+                                <ToggleButtonGroup
+                                    value={multiplier}
+                                    exclusive
+                                    onChange={handleMultiplier}
+                                    aria-label="recipe multiplier"
+                                    sx={{p: theme.spacing(2.5)}}
+                                    color='primary'
+                                >
+                                    <ToggleButton value={1/2} aria-label="one half times">
+                                        <Typography sx={{ fontWeight: 900 }}>½×</Typography>
+                                    </ToggleButton>
+                                    <ToggleButton value={1} aria-label="one times">
+                                        <Typography sx={{ fontWeight: 900 }}>1×</Typography>
+                                    </ToggleButton>
+                                    <ToggleButton value={2} aria-label="two times">
+                                        <Typography sx={{ fontWeight: 900 }}>2×</Typography>
+                                    </ToggleButton>
+                                    <ToggleButton value={3} aria-label="three times">
+                                        <Typography sx={{ fontWeight: 900 }}>3×</Typography>
+                                    </ToggleButton>
+                                </ToggleButtonGroup>
+
 
                                 {'wakeLock' in navigator &&
                                     <FormGroup>

--- a/src/utils/RecipeCardHelpers.tsx
+++ b/src/utils/RecipeCardHelpers.tsx
@@ -1,0 +1,131 @@
+import React from "react"
+import Grid from "@mui/material/Grid"
+import Typography from "@mui/material/Typography"
+import Ingredient, { ingredientToString } from "./ingredient"
+import { theme } from "./theme"
+
+export const generateCategories = (multiplier: number, ingredients: Ingredient[][], categories?: string[]) => {
+    if (categories) {
+        let retval: JSX.Element[] = []
+        let end = Math.min(categories.length, ingredients.length)
+        for (let i = 0; i < end; ++i) {
+            retval.push((
+                <React.Fragment key={categories[i]}>
+                    <Grid item xs={1}>
+                    </Grid>
+
+                    <Grid item xs={10}>
+                        <Typography sx={{
+                            fontFamily: 'Karla',
+                            fontWeight: 700,
+                            color: 'black',
+                            marginTop: theme.spacing(4)
+                        }}
+                            gutterBottom
+                            variant="body1"
+                            component="div">
+                            {categories[i]}
+                        </Typography>
+
+                        <ul>
+                            {ingredients[i].filter(ingredient => !ingredient.hidden).map(ingredient => (
+                                <li key={ingredient.key} dangerouslySetInnerHTML={{ __html: ingredientToString(ingredient, multiplier) }} style={{
+                                    fontFamily: 'Karla',
+                                    color: 'black',
+                                    fontWeight: 500,
+                                    fontSize: theme.spacing(4),
+                                }} />
+                            ))}
+                        </ul>
+                    </Grid>
+
+                    <Grid item xs={1}>
+                    </Grid>
+                </React.Fragment>
+            ))
+        }
+        return retval
+    } else {
+        return ingredients.map(ingredients => (
+            <React.Fragment key={ingredients.join(',')}>
+                <Grid item xs={1}>
+                </Grid>
+
+                <Grid item xs={10}>
+                    <ul>
+                        {ingredients.filter(ingredient => !ingredient.hidden).map(ingredient => (
+                            <li key={ingredient.key} dangerouslySetInnerHTML={{ __html: ingredientToString(ingredient, multiplier) }} style={{
+                                fontFamily: 'Karla',
+                                color: 'black',
+                                fontWeight: 500,
+                                fontSize: theme.spacing(4),
+                            }} />
+                        ))}
+                    </ul>
+                </Grid>
+
+                <Grid item xs={1}>
+                </Grid>
+            </React.Fragment>
+        ))
+    }
+}
+
+const dynamicStep = (step: string, multiplier: number, flattenedIngredients: Ingredient[], serves: number) => {
+    step = step.replaceAll(`!serves`, `${serves * multiplier}`)
+    flattenedIngredients.forEach((ingredient) => {
+        step = step.replaceAll(`!${ingredient.key}`, () => ingredientToString(ingredient, multiplier))
+    })
+    return step
+}
+
+export const generateSteps = (steps: string[], multiplier: number, ingredients: Ingredient[][], serves: number) => {
+    const flattenedIngredients = ingredients.flat().sort((a, b) => b.key.localeCompare(a.key))
+    return (
+        <>
+            <Grid item xs={1}>
+            </Grid>
+
+            <Grid item xs={10}>
+                <Typography sx={{
+                    fontFamily: 'Jost',
+                    fontWeight: 700,
+                    color: 'black',
+                    marginTop: theme.spacing(8)
+                }}
+                    gutterBottom
+                    variant="body1"
+                    component="div">
+                    Steps
+                </Typography>
+            </Grid>
+
+            <Grid item xs={1}>
+            </Grid>
+
+
+            <Grid item xs={1}>
+            </Grid>
+
+            <Grid item xs={10}>
+
+
+
+                <ol>
+                    {steps.map(step => (
+                        <li key={step} dangerouslySetInnerHTML={{ __html: dynamicStep(step, multiplier, flattenedIngredients, serves) }} style={{
+                            fontFamily: 'Karla',
+                            color: 'black',
+                            fontWeight: 500,
+                            fontSize: theme.spacing(4),
+                        }} />
+                    ))}
+                </ol>
+
+            </Grid>
+
+            <Grid item xs={1}>
+            </Grid>
+        </>
+    )
+}

--- a/src/utils/ingredient.ts
+++ b/src/utils/ingredient.ts
@@ -1,0 +1,63 @@
+import { units, unitToString } from "./unit"
+
+interface Ingredient {
+    key: string
+    quantity?: number
+    unitTag?: string
+    ingredient?: string
+    hidden?: boolean
+}
+
+const unicodeFractions = {
+    '¼': 1 / 4,
+    '½': 1 / 2,
+    '¾': 3 / 4,
+    '⅐': 1 / 7,
+    '⅑': 1 / 9,
+    '⅒': 1 / 10,
+    '⅓': 1 / 3,
+    '⅔': 2 / 3,
+    '⅕': 1 / 5,
+    '⅖': 2 / 5,
+    '⅗': 3 / 5,
+    '⅘': 4 / 5,
+    '⅙': 1 / 6,
+    '⅚': 5 / 6,
+    '⅛': 1 / 8,
+    '⅜': 3 / 8,
+    '⅝': 5 / 8,
+    '⅞': 7 / 8,
+    '1': 1
+}
+
+const numberPrettifier = (number: number) => {
+    const characteristic = Math.floor(number)
+    const mantissa = number - characteristic
+    if (number === characteristic) { return `${number}` }
+    let distance = Infinity
+    let closest = ""
+    for (const [key, value] of Object.entries(unicodeFractions)) {
+        const difference = Math.abs(mantissa - value)
+        if (difference < distance) {
+            distance = difference
+            closest = key
+        }
+    }
+    if (closest === '1') { return `${characteristic + 1}` }
+    if (characteristic !== 0) { return `${characteristic} ${closest}` }
+    return `${closest}`
+}
+
+export const ingredientToString = (ingredient: Ingredient, multiplier: number = 1) => {
+    if (ingredient.quantity && ingredient.unitTag) {
+        const trueQuantity = ingredient.quantity * multiplier
+        if (ingredient.ingredient) { return `${numberPrettifier(trueQuantity)} ${unitToString(trueQuantity, units[ingredient.unitTag])} ${ingredient.ingredient}` }
+        return `${numberPrettifier(trueQuantity)} ${unitToString(trueQuantity, units[ingredient.unitTag])}`
+    } else if (ingredient.ingredient) {
+        return `${ingredient.ingredient}`
+    } else {
+        return `${ingredient.key}`
+    }
+}
+
+export default Ingredient

--- a/src/utils/recipe.d.ts
+++ b/src/utils/recipe.d.ts
@@ -1,3 +1,5 @@
+import { Ingredient } from "./ingredient";
+
 export default interface Recipe {
     path: string,
     image: string,
@@ -6,7 +8,7 @@ export default interface Recipe {
     subtitle: string,
     subtitle2: string,
     categories?: string[],
-    ingredients: string[][],
+    ingredients: Ingredient[][],
     steps: string[],
     preptime: string,
     cooktime: string,
@@ -14,4 +16,5 @@ export default interface Recipe {
     serves: number,
     alt?: string,
     icon_alt?: string,
+    indivisible?: boolean
 }

--- a/src/utils/unit.ts
+++ b/src/utils/unit.ts
@@ -1,0 +1,134 @@
+interface Unit {
+    readonly singular: string
+    readonly fractional?: string
+    readonly plural?: string
+}
+
+export const units: { [tag: string]: Unit } = {
+    box: {
+        fractional: 'a box',
+        singular: 'box',
+        plural: 'boxes'
+    },
+    can: {
+        fractional: 'a can',
+        singular: 'can',
+        plural: 'cans'
+    },
+    carrot: {
+        fractional: 'a carrot',
+        singular: 'carrot',
+        plural: 'carrots'
+    },
+    cup: {
+        fractional: 'cup',
+        singular: 'cup',
+        plural: 'cups'
+    },
+    'cherry tomato': {
+        fractional: 'a cherry tomato',
+        singular: 'cherry tomato',
+        plural: 'cherry tomatoes'
+    },
+    clove: {
+        fractional: 'a clove',
+        singular: 'clove',
+        plural: 'cloves'
+    },
+    egg: {
+        fractional: 'an egg',
+        singular: 'egg',
+        plural: 'eggs'
+    },
+    'espresso shot': {
+        fractional: 'an espresso shot',
+        singular: 'espresso shot',
+        plural: 'espresso shots'
+    },
+    gram: {
+        singular: 'g'
+    },
+    'green onion': {
+        fractional: 'a green onion',
+        singular: 'green onion',
+        plural: 'green onions'
+    },
+    'jalapeno pepper': {
+        fractional: 'a jalapeño pepper',
+        singular: 'jalapeño pepper',
+        plural: 'jalapeño peppers'
+    },
+    'large carrot': {
+        fractional: 'a large carrot',
+        singular: 'large carrot',
+        plural: 'large carrots'
+    },
+    'large egg': {
+        fractional: 'a large egg',
+        singular: 'large egg',
+        plural: 'large eggs'
+    },
+    'large egg white': {
+        fractional: 'a large egg white',
+        singular: 'large egg white',
+        plural: 'large egg whites'
+    },
+    lime: {
+        fractional: 'a lime',
+        singular: 'lime',
+        plural: 'limes'
+    },
+    onion: {
+        fractional: 'an onion',
+        singular: 'onion',
+        plural: 'onions'
+    },
+    oz: {
+        singular: 'oz'
+    },
+    package: {
+        fractional: 'a package',
+        singular: 'package',
+        plural: 'packages'
+    },
+    ramekin: {
+        fractional: 'a ramekin',
+        singular: 'ramekin',
+        plural: 'ramekins'
+    },
+    'single 9 inch pie crust': {
+        fractional: 'a single 9 inch pie crust',
+        singular: 'single 9 inch pie crust',
+        plural: 'single 9 inch pie crusts'
+    },
+    'small box': {
+        fractional: 'a small box',
+        singular: 'small box',
+        plural: 'small boxes'
+    },
+    'small white or yellow onion': {
+        fractional: 'a small white or yellow onion',
+        singular: 'small white or yellow onion',
+        plural: 'small white or yellow onions'
+    },
+    stick: {
+        fractional: 'a stick',
+        singular: 'stick',
+        plural: 'sticks'
+    },
+    tbsp: {
+        singular: 'tbsp'
+    },
+    tsp: {
+        singular: 'tsp'
+    }
+}
+
+export const unitToString = (quantity: number, _unit: Unit) => {
+    if (quantity < 0) { return '' }
+    if (quantity === 0 || quantity > 1) { return _unit.plural ?? _unit.singular }
+    if (quantity < 1) { return _unit.fractional ?? _unit.singular }
+    return _unit.singular
+}
+
+export default Unit


### PR DESCRIPTION
Add buttons under the `Serves ##` header that enable the user to adjust the number of servings for each recipe.

Ingredients and servings are adjusted and ingredients can be tagged with a bang (`!`) in the steps section by their `key` to refer to the specific quantity in the ingredients list.

Ingredients have an optional `hidden` property that does not display them in the list of ingredients, but which can be used for bang-replacement in the Steps.

Recipes can now be marked as `indivisible` which disables the ½ button for the given recipe. This is intended for things like a pie, a cup of coffee, etc.

Units are agglomerated in the `src/utils/units.ts` file, where they are declared by the `unitTag` and then defined by giving a `singular` form with options for `fractional` (<1) and `plural` (0 or >1) forms.

This means that writing recipes takes a little longer as one needs to define each ingredient as an object with a quantity, unitTag, ingredient, and key as can be found in `src/utils/ingredients.ts`. The `key` must be unique for React to handle the ingredient properly. It is also used for bang-replacement so should be unique on a per recipe basis.

My standard key form is `category-ingredient` to guarantee uniqueness. Though any unique string is a valid key.

Ingredients should either have quantity **and** unitTag or ingredient at the very least. You can combine all three, and this is the standard behavior, but do not omit quantity and supply a unitTag or vice-versa as both fields will be ignored in these scenarios.